### PR TITLE
ResidualBlock layer fix

### DIFF
--- a/src/api/batch_predictor.py
+++ b/src/api/batch_predictor.py
@@ -245,20 +245,19 @@ def create_model(model_path: str,
     """
 
     from model import CERMetric, WERMetric, CTCLoss
-    from utils import Utils
+    from custom_layers import ResidualBlock
+    from utils import Utils, load_model_from_directory
 
     logger = logging.getLogger(__name__)
 
-    # Register custom objects
-    get_custom_objects().update({
+    logger.info("Loading model...")
+    custom_objects = {
         'CERMetric': CERMetric,
         'WERMetric': WERMetric,
         'CTCLoss': CTCLoss,
-    })
-    logger.debug("Custom objects registered")
-
-    logger.info("Loading model...")
-    model = tf.keras.saving.load_model(model_path)
+        'ResidualBlock': ResidualBlock
+    }
+    model = load_model_from_directory(model_path, custom_objects)
     logger.info("Model loaded successfully")
 
     model_channels = model.input_shape[3]

--- a/src/api/batch_predictor.py
+++ b/src/api/batch_predictor.py
@@ -12,7 +12,6 @@ import gc
 
 # > Third-party dependencies
 import tensorflow as tf
-from tensorflow.keras.utils import get_custom_objects
 from tensorflow.keras import mixed_precision
 
 

--- a/src/api/image_preparator.py
+++ b/src/api/image_preparator.py
@@ -44,7 +44,12 @@ def image_preparation_worker(batch_size: int,
     # Disable GPU visibility to prevent memory allocation issues
     tf.config.set_visible_devices([], 'GPU')
 
-    num_channels = get_model_channels(model_path)
+    try:
+        num_channels = get_model_channels(model_path)
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        logger.error("Error retrieving number of channels. Exiting...")
+        return
     logger.debug(f"Input channels: {num_channels}")
 
     # Define the maximum time to wait for new images

--- a/src/api/image_preparator.py
+++ b/src/api/image_preparator.py
@@ -1,9 +1,11 @@
 # Imports
 
 # > Standard library
+import json
 import logging
 import multiprocessing
 from multiprocessing.queues import Empty
+import os
 
 # > Third-party dependencies
 import numpy as np
@@ -42,16 +44,8 @@ def image_preparation_worker(batch_size: int,
     # Disable GPU visibility to prevent memory allocation issues
     tf.config.set_visible_devices([], 'GPU')
 
-    # Load the saved model to get the input tensor shape
-    model = tf.saved_model.load(model_path)
-
-    # Get the concrete function from the saved model
-    concrete_func = model.signatures[tf.saved_model
-                                     .DEFAULT_SERVING_SIGNATURE_DEF_KEY]
-
-    # Get the input tensor shape
-    num_channels = concrete_func.inputs[0].shape.as_list()[-1]
-    logger.debug(f"Input tensor shape: {concrete_func.inputs[0].shape}")
+    num_channels = get_model_channels(model_path)
+    logger.debug(f"Input channels: {num_channels}")
 
     # Define the maximum time to wait for new images
     TIMEOUT_DURATION = 1
@@ -199,3 +193,50 @@ def prepare_image(identifier: str,
     image = tf.transpose(image, perm=[1, 0, 2])
 
     return image
+
+
+def get_model_channels(config_path: str) -> int:
+    """
+    Retrieve the number of input channels for a model from a configuration
+    file.
+
+    This function reads a JSON configuration file located in the specified
+    directory to extract the number of input channels used by the model.
+
+    Parameters
+    ----------
+    config_path : str
+        The path to the directory containing the 'config.json' file.
+        The function will append "/config.json" to this path.
+
+    Returns
+    -------
+    int
+        The number of input channels specified in the configuration file.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the 'config.json' file does not exist in the given directory.
+
+    ValueError
+        If the number of channels is not found or not specified in the
+        'config.json' file.
+    """
+
+    config_path = os.path.join(config_path, "config.json")
+
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(
+            f"Config file not found in the directory: {config_path}")
+
+    # Load the configuration file
+    with open(config_path, 'r') as file:
+        config = json.load(file)
+
+    # Extract the number of channels
+    num_channels = config.get("args", {}).get("channels")
+    if num_channels is None:
+        raise ValueError("Number of channels not found in the config file.")
+
+    return num_channels

--- a/src/custom_layers.py
+++ b/src/custom_layers.py
@@ -6,74 +6,202 @@
 
 # > Third party libraries
 import tensorflow as tf
-import keras
-from tensorflow.keras import layers
 
 
-class ResidualBlock(layers.Layer):
-    def __init__(self, filters, x, y, initializer=tf.initializers.GlorotNormal, downsample=False):
-        super().__init__()
+# @tf.keras.utils.register_keras_serializable()
+class ResidualBlock(tf.keras.layers.Layer):
+    """
+    A residual block layer for a neural network.
+
+    This layer applies two convolutional layers, each followed by batch
+    normalization and an activation function.
+    If downsampling is specified, it also applies a convolutional layer to
+    the shortcut connection.
+
+    Parameters
+    ----------
+    filters : int
+        The number of filters for the convolutional layers.
+    kernel_size : int or tuple of int
+        The size of the kernel to use in the convolutional layers.
+    initializer : tf.keras.initializers.Initializer,
+                  default=tf.initializers.GlorotNormal()
+        Initializer for the kernel weights of the convolutional layers.
+    downsample : bool, default=False
+        Whether to downsample the input feature maps using strides.
+    activation : str, default='elu'
+        Activation function to use after the convolutional layers.
+    regularizer : tf.keras.regularizers.Regularizer, optional
+        Regularizer function applied to the kernel weights of the
+        convolutional layers.
+
+    Attributes
+    ----------
+    conv1 : tf.keras.layers.Conv2D
+        The first convolutional layer in the block.
+    conv2 : tf.keras.layers.Conv2D
+        The second convolutional layer in the block.
+    bn1 : tf.keras.layers.BatchNormalization
+        Batch normalization layer following conv1.
+    bn2 : tf.keras.layers.BatchNormalization
+        Batch normalization layer following conv2.
+    downsample_conv : tf.keras.layers.Conv2D
+        Convolutional layer used in the shortcut path for downsampling, if
+        applicable.
+    activation_layer : tf.keras.layers.Activation
+        The activation layer applied after each batch normalization.
+
+    Methods
+    -------
+    build(input_shape)
+        Builds the residual block based on the input shape.
+    call(inputs, training=False)
+        Performs the forward pass on the inputs.
+    get_config()
+        Returns the configuration of the residual block.
+    """
+
+    def __init__(self,
+                 filters,
+                 kernel_size,
+                 initializer=tf.initializers.GlorotNormal(),
+                 downsample=False,
+                 activation='elu',
+                 regularizer=None,
+                 **kwargs):
+
+        super().__init__(**kwargs)
+        self.filters = filters
+        self.kernel_size = kernel_size
+        self.initializer = initializer
         self.downsample = downsample
-        self.conv1 = layers.Conv2D(filters,
-                                   kernel_size=(x, y),
-                                   strides=(1, 1)
-                                   if not downsample else (2, 2),
-                                   padding="same",
-                                   activation='elu',
-                                   kernel_initializer=initializer)
+        self.activation = activation
+        self.regularizer = regularizer
+        self.strides = 2 if downsample else 1
 
-        self.conv2 = layers.Conv2D(filters,
-                                   kernel_size=(x, y),
-                                   strides=(1, 1),
-                                   padding="same",
-                                   activation='elu',
-                                   kernel_initializer=initializer)
+    def build(self, input_shape):
+        """
+        Create the layer based on input shape. This method creates the
+        convolutional, batch normalization, and activation layers based on the
+        input shape.
 
-        if downsample:
-            self.conv3 = layers.Conv2D(filters,
-                                       kernel_size=(1, 1),
-                                       strides=(2, 2),
-                                       padding="same",
-                                       activation="elu",
-                                       kernel_initializer=initializer)
+        Parameters
+        ----------
+        input_shape : TensorShape
+            Shape of the input tensor.
+        """
 
-        # ELU and BatchNormalization layers
-        self.elu_layer = layers.ELU()
-        self.bn_layer = layers.BatchNormalization()
+        self.conv1 = tf.keras.layers.Conv2D(
+            self.filters,
+            self.kernel_size,
+            strides=self.strides,
+            padding="same",
+            kernel_initializer=self.initializer,
+            kernel_regularizer=self.regularizer)
+        self.bn1 = tf.keras.layers.BatchNormalization()
+
+        self.conv2 = tf.keras.layers.Conv2D(
+            self.filters,
+            self.kernel_size,
+            strides=1,
+            padding="same",
+            kernel_initializer=self.initializer,
+            kernel_regularizer=self.regularizer)
+        self.bn2 = tf.keras.layers.BatchNormalization()
+
+        if self.downsample:
+            self.downsample_conv = tf.keras.layers.Conv2D(
+                self.filters,
+                (1, 1),
+                strides=2,
+                padding="same",
+                kernel_initializer=self.initializer,
+                kernel_regularizer=self.regularizer)
+
+        self.activation_layer = tf.keras.layers.Activation(self.activation)
+
+        super().build(input_shape)
+
+    def call(self, inputs, training=False):
+        """
+        Perform the forward pass of the residual block.
+
+        Parameters
+        ----------
+        inputs : tf.Tensor
+            Input tensor.
+        training : bool, default=False
+            Whether the layer should behave in training mode or inference mode.
+
+        Returns
+        -------
+        tf.Tensor
+            Output tensor of the residual block.
+        """
+
+        x = inputs
+        y = self.conv1(x)
+        y = self.bn1(y, training=training)
+        y = self.activation_layer(y)
+
+        y = self.conv2(y)
+        y = self.bn2(y, training=training)
+
+        if self.downsample:
+            x = self.downsample_conv(x)
+
+        y = tf.keras.layers.Add()([x, y])
+        return self.activation_layer(y)
 
     def get_config(self):
+        """
+        Returns the configuration of the residual block for serialization.
+
+        Returns
+        -------
+        dict
+            A Python dictionary containing the configuration of the residual
+            block.
+        """
+
         config = super().get_config()
         config.update({
-            'filters': self.conv1.filters,
-            'x': self.conv1.kernel_size[0],
-            'y': self.conv1.kernel_size[1],
-
-            # Serializing the initializer
-            'initializer': tf.keras.initializers.serialize(
-                self.conv1.kernel_initializer),
-            'downsample': self.downsample
+            'filters': self.filters,
+            'kernel_size': self.kernel_size,
+            'initializer': tf.keras.initializers.serialize(self.initializer),
+            'downsample': self.downsample,
+            'activation': self.activation,
+            'regularizer': tf.keras.regularizers.serialize(self.regularizer),
         })
         return config
 
-    def call(self, x, training=False):
-        y = self.conv1(x)
-        y = self.conv2(y)
-        if self.downsample:
-            x = self.conv3(x)
-        y = layers.Add()([x, y])
-        y = self.elu_bn(y)
-        return y
+    @classmethod
+    def from_config(cls, config):
+        """
+        Creates a residual block from a configuration dictionary.
 
-    def elu_bn(self, inputs):
-        elu = self.elu_layer(inputs)
-        bn = self.bn_layer(elu)
-        return bn
+        Parameters
+        ----------
+        config : dict
+            Configuration dictionary for the residual block.
+
+        Returns
+        -------
+        ResidualBlock
+            The residual block layer.
+        """
+        config['initializer'] = tf.keras.initializers.deserialize(
+            config['initializer'])
+        config['regularizer'] = tf.keras.regularizers.deserialize(
+            config['regularizer'])
+
+        return cls(**config)
 
 
-class CTCLayer(layers.Layer):
+class CTCLayer(tf.keras.layers.Layer):
     def __init__(self, name=None):
         super().__init__(name=name)
-        self.loss_fn = keras.backend.ctc_batch_cost
+        self.loss_fn = tf.keras.backend.ctc_batch_cost
 
     def call(self, y_true, y_pred):
         batch_len = tf.cast(tf.shape(y_true)[0], dtype="int64")

--- a/src/custom_layers.py
+++ b/src/custom_layers.py
@@ -8,7 +8,6 @@
 import tensorflow as tf
 
 
-# @tf.keras.utils.register_keras_serializable()
 class ResidualBlock(tf.keras.layers.Layer):
     """
     A residual block layer for a neural network.

--- a/src/loghi_custom_callback.py
+++ b/src/loghi_custom_callback.py
@@ -8,6 +8,7 @@ import json
 # > Third party libraries
 from tensorflow import keras
 
+
 class LoghiCustomCallback(keras.callbacks.Callback):
 
     previous_loss = float('inf')
@@ -21,7 +22,8 @@ class LoghiCustomCallback(keras.callbacks.Callback):
 
     def save_model(self, subdir):
         outputdir = os.path.join(self.output, subdir)
-        self.model.save(outputdir)
+        os.makedirs(outputdir, exist_ok=True)
+        self.model.save(outputdir + '/model.keras')
         with open(os.path.join(outputdir, 'charlist.txt'), 'w') as chars_file:
             chars_file.write(str().join(self.charlist))
         if self.metadata is not None:

--- a/src/main.py
+++ b/src/main.py
@@ -65,10 +65,9 @@ def main():
 
     # place from/imports here so os.environ["CUDA_VISIBLE_DEVICES"]  is set before TF loads
     from model import CERMetric, WERMetric, CTCLoss
-    from tensorflow.keras.utils import get_custom_objects
     import tensorflow.keras as keras
-    # strategy = tf.distribute.MirroredStrategy()
-    # print('Number of devices: {}'.format(strategy.num_replicas_in_sync))
+    strategy = tf.distribute.MirroredStrategy()
+    print('Number of devices: {}'.format(strategy.num_replicas_in_sync))
 
     if not args.use_float32 and args.gpu != '-1':
         print("using mixed_float16")
@@ -94,8 +93,7 @@ def main():
         charlist_location = args.output + '/charlist.txt'
     model_channels = args.channels
     model_height = args.height
-    # with strategy.scope():
-    with tf.device('/gpu:0'):
+    with strategy.scope():
         if args.existing_model:
             if not os.path.exists(args.existing_model):
                 print('cannot find existing model on disk: ' + args.existing_model)
@@ -514,24 +512,24 @@ def main():
             totalcerwbs = totaleditdistance_wbs / float(totallength)
             totalcerwbslower = totaleditdistance_wbs_lower / float(totallength)
 
-        totalcer_lower = \
+        totalcer_lower = round(
             totalcer-(calc_confidence_interval(totalcer,
-                      pred_counter, certainty))
-        totalcer_upper = \
+                      pred_counter, certainty)), 4)
+        totalcer_upper = round(
             totalcer+(calc_confidence_interval(totalcer,
-                      pred_counter, certainty))
-        totalcerlower_lower = \
+                      pred_counter, certainty)), 4)
+        totalcerlower_lower = round(
             totalcerlower-(calc_confidence_interval(totalcerlower,
-                                                    pred_counter, certainty))
-        totalcerlower_upper = \
+                                                    pred_counter, certainty)), 4)
+        totalcerlower_upper = round(
             totalcerlower+(calc_confidence_interval(totalcerlower,
-                                                    pred_counter, certainty))
-        totalcersimple_lower = \
-            totalcersimple - \
-            (calc_confidence_interval(totalcersimple, pred_counter, certainty))
-        totalcersimple_upper = \
-            totalcersimple + \
-            (calc_confidence_interval(totalcersimple, pred_counter, certainty))
+                                                    pred_counter, certainty)), 4)
+        totalcersimple_lower = round(
+            totalcersimple -
+            (calc_confidence_interval(totalcersimple, pred_counter, certainty)), 4)
+        totalcersimple_upper = round(
+            totalcersimple +
+            (calc_confidence_interval(totalcersimple, pred_counter, certainty)), 4)
 
         print('totalcer: ' + str(totalcer) + "(" + str(certainty)+"%"+" certainty that totalcer is between "
               + str(totalcer_lower) + " and " + str(totalcer_upper) + ")")

--- a/src/main.py
+++ b/src/main.py
@@ -228,7 +228,7 @@ def main():
                 for layer in model.layers:
                     if args.thaw:
                         layer.trainable = True
-                    elif args.freeze_conv_layers and layer.name.lower().startswith("conv"):
+                    elif args.freeze_conv_layers and (layer.name.lower().startswith("conv") or layer.name.lower().startswith("residual")):
                         print(layer.name)
                         layer.trainable = False
                     elif args.freeze_recurrent_layers and layer.name.lower().startswith("bidirectional"):

--- a/src/model.py
+++ b/src/model.py
@@ -152,7 +152,6 @@ class WERMetric(tf.keras.metrics.Metric):
         self.counter.assign(0.0)
 
 
-@tf.function
 def CTCLoss(y_true, y_pred):
     batch_len = tf.cast(tf.shape(y_true)[0], dtype="int64")
     input_length = tf.cast(tf.shape(y_pred)[1], dtype="int64")

--- a/src/utils.py
+++ b/src/utils.py
@@ -220,7 +220,6 @@ def load_model_from_directory(directory, custom_objects=None):
     model_file = next((os.path.join(directory, file) for file in os.listdir(
         directory) if file.endswith(".keras")), None)
 
-    print(custom_objects)
     if model_file:
         return tf.keras.models.load_model(model_file, custom_objects=custom_objects)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,7 @@
 # Imports
 
 # > Standard Library
+import os
 
 # > Local dependencies
 
@@ -13,7 +14,8 @@ from tensorflow.python.ops import sparse_ops, array_ops, math_ops
 from tensorflow.python.ops import ctc_ops as ctc
 from numpy import exp
 
-class Utils():
+
+class Utils:
 
     def __init__(self, chars, use_mask):
         self.set_charlist(chars=chars, use_mask=use_mask)
@@ -53,6 +55,7 @@ class Utils():
                 invert=True
             )
 
+
 def shape(x):
     """Returns the symbolic shape of a tensor or variable.
 
@@ -74,6 +77,7 @@ def shape(x):
 
     """
     return array_ops.shape(x)
+
 
 def ctc_decode(y_pred, input_length, greedy=True, beam_width=100, top_paths=1):
     """Decodes the output of a softmax.
@@ -106,7 +110,8 @@ def ctc_decode(y_pred, input_length, greedy=True, beam_width=100, top_paths=1):
     """
     input_shape = shape(y_pred)
     num_samples, num_steps = input_shape[0], input_shape[1]
-    y_pred = math_ops.log(array_ops.transpose(y_pred, perm=[1, 0, 2]) + tf.keras.backend.epsilon())
+    y_pred = math_ops.log(array_ops.transpose(
+        y_pred, perm=[1, 0, 2]) + tf.keras.backend.epsilon())
     input_length = math_ops.cast(input_length, dtypes.int32)
 
     if greedy:
@@ -141,7 +146,8 @@ def decode_batch_predictions(pred, utils, greedy=True, beam_width=1, num_oov_ind
     # np.savetxt("foo.csv", pred_matrix, delimiter=",")
     top_paths = 1
     output_texts = []
-    ctc_decoded = ctc_decode(pred, input_length=input_len, greedy=greedy, beam_width=beam_width, top_paths=top_paths)
+    ctc_decoded = ctc_decode(pred, input_length=input_len,
+                             greedy=greedy, beam_width=beam_width, top_paths=top_paths)
     for top_path in range(0, top_paths):
         results = ctc_decoded[0][top_path][:, :]
         # log_prob = ctc_decoded[1][0][top_path]
@@ -170,12 +176,14 @@ def decode_batch_predictions(pred, utils, greedy=True, beam_width=1, num_oov_ind
         output_texts.append(output_text)
     return output_texts
 
+
 def deprocess_image(img):
     img /= 2.0
     img += 0.5
     img *= 255.
     img = np.clip(img, 0, 255).astype("uint8")
     return img
+
 
 def initialize_image(channels):
     # We start from a gray image with some random noise
@@ -184,13 +192,15 @@ def initialize_image(channels):
     # Here we scale our random inputs to [-0.125, +0.125]
     return (img - 0.5) * 0.25
 
+
 def get_feature_maps(model, layer_id, input_image):
-    model_ = Model(inputs=[model.input]
-                   , outputs=[model.layers[layer_id].output])
+    model_ = Model(inputs=[model.input], outputs=[
+                   model.layers[layer_id].output])
     print(model.layers[layer_id].name)
     # img = tf.transpose(img, perm=[1, 0, 2])
 
     return model_.predict(np.expand_dims(input_image, axis=0))[0, :, :, :].transpose((2, 1, 0))
+
 
 def normalize_confidence(confidence, predicted_text):
     if len(predicted_text) > 0:
@@ -199,3 +209,19 @@ def normalize_confidence(confidence, predicted_text):
         if confidence < 0:
             confidence = -confidence
     return confidence
+
+
+def load_model_from_directory(directory, custom_objects=None):
+    # Check for a .pb file (indicating SavedModel format)
+    if any(file.endswith('.pb') for file in os.listdir(directory)):
+        return tf.keras.models.load_model(directory, custom_objects=custom_objects)
+
+    # Look for a .keras file
+    model_file = next((os.path.join(directory, file) for file in os.listdir(
+        directory) if file.endswith(".keras")), None)
+
+    print(custom_objects)
+    if model_file:
+        return tf.keras.models.load_model(model_file, custom_objects=custom_objects)
+
+    raise FileNotFoundError("No suitable model file found in the directory.")

--- a/src/vgsl_model_generator.py
+++ b/src/vgsl_model_generator.py
@@ -204,9 +204,9 @@ class VGSLModelGenerator:
                         self.avgpool_generator(layer))
                 self.history.append(f"avgpool_{index}")
             elif layer.startswith('RB'):
-                # setattr(self, f"ResidualBlock_{index}",
-                self.residual_block_generator(layer, index)
-                # self.history.append(f"ResidualBlock_{index}")
+                setattr(self, f"ResidualBlock_{index}",
+                        self.residual_block_generator(layer, index))
+                self.history.append(f"ResidualBlock_{index}")
             elif layer.startswith('D'):
                 setattr(self, f"dropout_{index}",
                         self.dropout_generator(layer))
@@ -238,23 +238,11 @@ class VGSLModelGenerator:
                              "VGSL-spec string.")
 
         x = self.inputs
-        residual_block_x = None
         for index, layer in enumerate(self.history):
             if layer.startswith("reshape"):
                 x = self.reshape_generator(layer.split("_")[2], x)(x)
             else:
-                if layer.startswith('conv') and layer.endswith("_conv1_rb"):
-                    residual_block_x = x
-                if not layer.lower().startswith('elu_'):
-                    x = getattr(self, layer)(x)
-                if layer.lower().startswith('conv') and getattr(self, layer).name.endswith("_conv3_rb"):
-                    residual_block_x = x
-                if layer.startswith('elu') \
-                        and getattr(self, layer).name.startswith("elu_") \
-                        and getattr(self, layer).name.endswith("_rb"):
-                    print('layer '+layer)            #elu
-                    x = layers.Add()([residual_block_x, x])
-                    residual_block_x = None
+                x = getattr(self, layer)(x)
         output = layers.Activation('linear', dtype=tf.float32)(x)
 
         logging.info("Model has been built\n")
@@ -314,21 +302,11 @@ class VGSLModelGenerator:
                 ("None,64,None,1 Ce3,3,8 Bn Mp2,2,2,2 Ce3,3,12 Bn Ce3,3,20 Bn "
                  "Ce3,3,32 Bn Ce3,3,48 Bn Rc Lfs128,D50 Lfs128,D50 Lfs128,D50 "
                  "Lfs128,D50 Lfs128,D50 O1s92"),
-            # "model17":
-            #     ("None,64,None,4 Bn Ce3,3,16 RB3,3,16 RB3,3,16 RBd3,3,32 "
-            #      "RB3,3,32 RB3,3,32 RB3,3,32 RB3,3,32 RBd3,3,64 RB3,3,64 "
-            #      "RB3,3,64 RB3,3,64 RB3,3,64 RBd3,3,128 RB3,3,128 Rc "
-            #      "Bl256,D50 Bl256,D50 Bl256,D50 Bl256,D50 Bl256,D50 "
-            #      "O1s92")
             "model17":
-                ("None,64,None,4 Bn Ce3,3,16 "
-                 "RB3,3,16 RB3,3,16 "
-                 "RBd3,3,32 RB3,3,32 RB3,3,32 RB3,3,32 RB3,3,32"
-                 "RBd3,3,64 RB3,3,64 RB3,3,64 RB3,3,64 RB3,3,64 "
-                 "RBd3,3,128 RB3,3,128"
-                 "Rc "
-                 "Bl256,D20 Bl256,D20 Bl256,D20 "
-                 "O1s92")
+                ("None,64,None,4 Bn Ce3,3,16 RB3,3,16 RB3,3,16 RBd3,3,32 "
+                 "RB3,3,32 RB3,3,32 RB3,3,32 RB3,3,32 RBd3,3,64 RB3,3,64 "
+                 "RB3,3,64 RB3,3,64 RB3,3,64 RBd3,3,128 RB3,3,128 Rc "
+                 "Bl256,D20 Bl256,D20 Bl256,D20 O1s92")
         }
 
         return model_library
@@ -360,7 +338,7 @@ class VGSLModelGenerator:
     #   Helper functions   #
     ########################
 
-    @staticmethod
+    @ staticmethod
     def model_to_vgsl(model: tf.keras.models.Model) -> str:
         """
         Convert a Keras model to a VGSL spec string.
@@ -1205,26 +1183,7 @@ class VGSLModelGenerator:
                 f"Invalid parameters x={x}, y={y}, d={d} in layer {layer}. "
                 "All values should be positive integers.")
 
-        stride = ',1,1,'
-        spec = 'Ce,' + str(x)+',' + str(y) + stride + str(d)
-        setattr(self, f"conv2d_{index}_conv1_rb", self.conv2d_generator(spec))
-        self.history.append(f"conv2d_{index}_conv1_rb")
-
-        spec = 'Ce,'+str(x)+','+str(y)+',1,1,' + str(d)
-        setattr(self, f"conv2d_{index}_conv2_rb", self.conv2d_generator(spec))
-        self.history.append(f"conv2d_{index}_conv2_rb")
-
-        if downsample:
-            spec = 'Ce,' + str(x) + ',' + str(y) + ',2,2,' + str(d)
-            setattr(self, f"conv2d_{index}_conv3_rb", self.conv2d_generator(spec, name=f"conv2d_{index}_conv3_rb"))
-            self.history.append(f"conv2d_{index}_conv3_rb")
-
-        setattr(self, f"elu_{index}_rb", layers.ELU(name=f"elu_{index}_rb"))
-        self.history.append(f"elu_{index}_rb")
-
-        setattr(self, f"batchnorm_{index}_rb", layers.BatchNormalization(
-            axis=self._channel_axis))
-        self.history.append(f"batchnorm_{index}_rb")
+        return ResidualBlock(d, (x, y), self._initializer, bool(downsample))
 
     def dropout_generator(self,
                           layer: str) -> tf.keras.layers.Dropout:

--- a/tests/test_model_to_vgsl.py
+++ b/tests/test_model_to_vgsl.py
@@ -281,7 +281,7 @@ class TestModelToVGSL(unittest.TestCase):
         # Basic residual block
         model = tf.keras.Sequential([
             layers.Input(shape=(None, 64, 1)),
-            self.ResidualBlock(32, 3, 3)
+            self.ResidualBlock(32, (3, 3))
         ])
 
         vgsl_spec = self.VGSLModelGenerator.model_to_vgsl(model)
@@ -290,73 +290,73 @@ class TestModelToVGSL(unittest.TestCase):
         # Alternative residual block
         model = tf.keras.Sequential([
             layers.Input(shape=(None, 64, 1)),
-            self.ResidualBlock(16, 4, 2, downsample=True)
+            self.ResidualBlock(16, (4, 2), downsample=True)
         ])
 
         vgsl_spec = self.VGSLModelGenerator.model_to_vgsl(model)
         self.assertEqual(
             vgsl_spec, "None,64,None,1 RBd4,2,16")
 
-    # def test_functional_combination_to_vgsl(self):
-    #     # Define the original model using the functional API
-    #     input_tensor = layers.Input(shape=(None, 64, 1))
-    #     x = layers.Conv2D(32, (3, 3), activation='relu')(input_tensor)
-    #     x = layers.MaxPooling2D(pool_size=(2, 2))(x)
-    #     x = layers.AveragePooling2D(pool_size=(2, 2), strides=(1, 1))(x)
-    #     x = layers.BatchNormalization()(x)
-    #     x = layers.Dropout(0.25)(x)
-    #     x = self.ResidualBlock(32, 3, 3)(x)
-    #     x = layers.Reshape((-1, 1024))(x)
-    #     x = layers.LSTM(64, return_sequences=True)(x)
-    #     x = layers.GRU(64, return_sequences=True, go_backwards=True)(x)
-    #     x = layers.Bidirectional(layers.LSTM(256, return_sequences=True))(x)
-    #     x = layers.Bidirectional(layers.GRU(256, return_sequences=True))(x)
-    #     x = layers.Dense(10, activation='softmax')(x)
-    #     output_tensor = layers.Activation('linear')(x)
-    #     model = tf.keras.Model(inputs=input_tensor, outputs=output_tensor)
-    # 
-    #     vgsl_spec = self.VGSLModelGenerator.model_to_vgsl(model)
-    #     self.assertEqual(
-    #         vgsl_spec, "None,64,None,1 Cr3,3,32 Mp2,2,2,2 Ap2,2,1,1 Bn D25 "
-    #                    "RB3,3,32 Rc Lfs64 Grs64 Bl256 Bg256 O1s10")
-    # 
-    #     # Generate a model from the VGSL string
-    #     model_generator = self.VGSLModelGenerator(vgsl_spec)
-    #     generated_model = model_generator.build()
-    # 
-    #     # Compare the original model with the generated model
-    #     self.compare_model_configs(model, generated_model)
+    def test_functional_combination_to_vgsl(self):
+        # Define the original model using the functional API
+        input_tensor = layers.Input(shape=(None, 64, 1))
+        x = layers.Conv2D(32, (3, 3), activation='relu')(input_tensor)
+        x = layers.MaxPooling2D(pool_size=(2, 2))(x)
+        x = layers.AveragePooling2D(pool_size=(2, 2), strides=(1, 1))(x)
+        x = layers.BatchNormalization()(x)
+        x = layers.Dropout(0.25)(x)
+        x = self.ResidualBlock(32, (3, 3))(x)
+        x = layers.Reshape((-1, 1024))(x)
+        x = layers.LSTM(64, return_sequences=True)(x)
+        x = layers.GRU(64, return_sequences=True, go_backwards=True)(x)
+        x = layers.Bidirectional(layers.LSTM(256, return_sequences=True))(x)
+        x = layers.Bidirectional(layers.GRU(256, return_sequences=True))(x)
+        x = layers.Dense(10, activation='softmax')(x)
+        output_tensor = layers.Activation('linear')(x)
+        model = tf.keras.Model(inputs=input_tensor, outputs=output_tensor)
 
-    # def test_sequential_combination_to_vgsl(self):
-    #     # Define the original model using the sequential API
-    #     model = tf.keras.Sequential([
-    #         layers.Input(shape=(None, 64, 1)),
-    #         layers.Conv2D(32, (3, 3), activation='relu'),
-    #         layers.MaxPooling2D(pool_size=(2, 2)),
-    #         layers.AveragePooling2D(pool_size=(2, 2), strides=(1, 1)),
-    #         layers.BatchNormalization(),
-    #         layers.Dropout(0.25),
-    #         self.ResidualBlock(32, 3, 3),
-    #         layers.Reshape((-1, 1024)),
-    #         layers.LSTM(64, return_sequences=True),
-    #         layers.GRU(64, return_sequences=True, go_backwards=True),
-    #         layers.Bidirectional(layers.LSTM(256, return_sequences=True)),
-    #         layers.Bidirectional(layers.GRU(256, return_sequences=True)),
-    #         layers.Dense(10, activation='softmax'),
-    #         layers.Activation('linear')
-    #     ])
-    #
-    #     vgsl_spec = self.VGSLModelGenerator.model_to_vgsl(model)
-    #     self.assertEqual(
-    #         vgsl_spec, "None,64,None,1 Cr3,3,32 Mp2,2,2,2 Ap2,2,1,1 Bn D25 "
-    #                    "RB3,3,32 Rc Lfs64 Grs64 Bl256 Bg256 O1s10")
-    #
-    #     # Generate a model from the VGSL string
-    #     model_generator = self.VGSLModelGenerator(vgsl_spec)
-    #     generated_model = model_generator.build()
-    #
-    #     # Compare the original model with the generated model
-    #     self.compare_model_configs(model, generated_model)
+        vgsl_spec = self.VGSLModelGenerator.model_to_vgsl(model)
+        self.assertEqual(
+            vgsl_spec, "None,64,None,1 Cr3,3,32 Mp2,2,2,2 Ap2,2,1,1 Bn D25 "
+                       "RB3,3,32 Rc Lfs64 Grs64 Bl256 Bg256 O1s10")
+
+        # Generate a model from the VGSL string
+        model_generator = self.VGSLModelGenerator(vgsl_spec)
+        generated_model = model_generator.build()
+
+        # Compare the original model with the generated model
+        self.compare_model_configs(model, generated_model)
+
+    def test_sequential_combination_to_vgsl(self):
+        # Define the original model using the sequential API
+        model = tf.keras.Sequential([
+            layers.Input(shape=(None, 64, 1)),
+            layers.Conv2D(32, (3, 3), activation='relu'),
+            layers.MaxPooling2D(pool_size=(2, 2)),
+            layers.AveragePooling2D(pool_size=(2, 2), strides=(1, 1)),
+            layers.BatchNormalization(),
+            layers.Dropout(0.25),
+            self.ResidualBlock(32, (3, 3)),
+            layers.Reshape((-1, 1024)),
+            layers.LSTM(64, return_sequences=True),
+            layers.GRU(64, return_sequences=True, go_backwards=True),
+            layers.Bidirectional(layers.LSTM(256, return_sequences=True)),
+            layers.Bidirectional(layers.GRU(256, return_sequences=True)),
+            layers.Dense(10, activation='softmax'),
+            layers.Activation('linear')
+        ])
+
+        vgsl_spec = self.VGSLModelGenerator.model_to_vgsl(model)
+        self.assertEqual(
+            vgsl_spec, "None,64,None,1 Cr3,3,32 Mp2,2,2,2 Ap2,2,1,1 Bn D25 "
+                       "RB3,3,32 Rc Lfs64 Grs64 Bl256 Bg256 O1s10")
+
+        # Generate a model from the VGSL string
+        model_generator = self.VGSLModelGenerator(vgsl_spec)
+        generated_model = model_generator.build()
+
+        # Compare the original model with the generated model
+        self.compare_model_configs(model, generated_model)
 
     def compare_model_configs(self, model, generated_model):
 


### PR DESCRIPTION
# This pull request adds

## ResidualBlock class

- Rewrite class, following Tensorflow standards
- Fixed bug where it was not possible to continue training a model that used the ResidualBlock layer
- Fixed bug where the ResidualBlock layers would still be trainable when `--freeze_conv_layers` arg was set

## Other

- Allow loading of both `.keras` type models and `.pb` type models
- Default saving method is now to recommended `.keras` format
- API gets the model channels from the `config.json` file