### PR TITLE
Dynamic model switching, OOM optimizations, extended error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,8 +303,6 @@ GUNICORN_ACCESSLOG       # Default: "-": Access log settings.
 **Loghi-HTR Options:**
 
 ```bash
-LOGHI_MODEL_PATH         # Path to the model.
-LOGHI_CHARLIST_PATH      # Path to the character list.
 LOGHI_BATCH_SIZE         # Default: "256": Batch size for processing.
 LOGHI_OUTPUT_PATH        # Directory where predictions are saved.
 LOGHI_MAX_QUEUE_SIZE     # Default: "10000": Maximum size of the processing queue.
@@ -323,10 +321,10 @@ You can set these variables in your shell or use a script. An example script to 
 Once the API is up and running, you can send HTR requests using curl. Here's how:
 
 ```bash
-curl -X POST -F "image=@$input_path" -F "group_id=$group_id" -F "identifier=$filename" http://localhost:5000/predict
+curl -X POST -F "image=@$input_path" -F "group_id=$group_id" -F "identifier=$filename" -F "model=$model_path" http://localhost:5000/predict
 ```
 
-Replace `$input_path`, `$group_id`, and `$filename` with your specific values. The model processes the image, predicts the handwritten text, and saves the predictions in the specified output path (from the `LOGHI_OUTPUT_PATH` environment variable).
+Replace `$input_path`, `$group_id`, `$filename`, and `$model_path` with your specific values. The model processes the image, predicts the handwritten text, and saves the predictions in the specified output path (from the `LOGHI_OUTPUT_PATH` environment variable).
 
 ---
 

--- a/src/api/app_utils.py
+++ b/src/api/app_utils.py
@@ -166,11 +166,13 @@ def start_processes(batch_size: int, max_queue_size: int,
     logger.info("Initializing request queue")
     manager = Manager()
     request_queue = manager.JoinableQueue(maxsize=max_queue_size//2)
+    logger.info(f"Request queue size: {max_queue_size//2}")
 
     # Max size of prepared queue is half of the max size of request queue
     # expressed in number of batches
     max_prepared_queue_size = max_queue_size // 2 // batch_size
     prepared_queue = manager.JoinableQueue(maxsize=max_prepared_queue_size)
+    logger.info(f"Prediction queue size: {max_prepared_queue_size}")
 
     # Start the image preparation process
     logger.info("Starting image preparation process")

--- a/src/api/app_utils.py
+++ b/src/api/app_utils.py
@@ -151,7 +151,7 @@ def get_env_variable(var_name: str, default_value: str = None) -> str:
 
 
 def start_processes(batch_size: int, max_queue_size: int, model_path: str,
-                    charlist_path: str, output_path: str, gpus: str):
+                    output_path: str, gpus: str):
     logger = logging.getLogger(__name__)
 
     # Create a thread-safe Queue
@@ -179,8 +179,7 @@ def start_processes(batch_size: int, max_queue_size: int, model_path: str,
     prediction_process = Process(
         target=batch_prediction_worker,
         args=(prepared_queue, model_path,
-              charlist_path, output_path,
-              gpus),
+              output_path, gpus),
         name="Batch Prediction Process")
     prediction_process.daemon = True
     prediction_process.start()

--- a/src/api/app_utils.py
+++ b/src/api/app_utils.py
@@ -62,25 +62,27 @@ def setup_logging(level: str = "INFO") -> logging.Logger:
     return logging.getLogger(__name__)
 
 
-def extract_request_data() -> Tuple[bytes, str, str]:
+def extract_request_data() -> Tuple[bytes, str, str, str]:
     """
     Extract image and other form data from the current request.
 
     Returns
     -------
-    tuple of (bytes, str, str)
+    tuple of (bytes, str, str, str)
         image_content : bytes
             Content of the uploaded image.
         group_id : str
             ID of the group from form data.
         identifier : str
             Identifier from form data.
+        model : str
+            Location of the model to use for prediction.
 
     Raises
     ------
     ValueError
-        If required data (image, group_id, identifier) is missing or if the
-        image format is invalid.
+        If required data (image, group_id, identifier, model) is missing or if
+        the image format is invalid.
     """
 
     # Extract the uploaded image
@@ -106,7 +108,13 @@ def extract_request_data() -> Tuple[bytes, str, str]:
     if not identifier:
         raise ValueError("No identifier provided.")
 
-    return image_content, group_id, identifier
+    model = request.form.get('model')
+    if not model:
+        raise ValueError("No model provided.")
+    if not os.path.exists(model):
+        raise ValueError(f"Model directory {model} does not exist.")
+
+    return image_content, group_id, identifier, model
 
 
 def get_env_variable(var_name: str, default_value: str = None) -> str:
@@ -150,7 +158,7 @@ def get_env_variable(var_name: str, default_value: str = None) -> str:
     return value
 
 
-def start_processes(batch_size: int, max_queue_size: int, model_path: str,
+def start_processes(batch_size: int, max_queue_size: int,
                     output_path: str, gpus: str):
     logger = logging.getLogger(__name__)
 
@@ -168,8 +176,7 @@ def start_processes(batch_size: int, max_queue_size: int, model_path: str,
     logger.info("Starting image preparation process")
     preparation_process = Process(
         target=image_preparation_worker,
-        args=(batch_size, request_queue,
-              prepared_queue, model_path),
+        args=(batch_size, request_queue, prepared_queue),
         name="Image Preparation Process")
     preparation_process.daemon = True
     preparation_process.start()
@@ -178,8 +185,7 @@ def start_processes(batch_size: int, max_queue_size: int, model_path: str,
     logger.info("Starting batch prediction process")
     prediction_process = Process(
         target=batch_prediction_worker,
-        args=(prepared_queue, model_path,
-              output_path, gpus),
+        args=(prepared_queue, output_path, gpus),
         name="Batch Prediction Process")
     prediction_process.daemon = True
     prediction_process.start()

--- a/src/api/batch_predictor.py
+++ b/src/api/batch_predictor.py
@@ -198,7 +198,7 @@ def create_model(model_path: str) -> Tuple[tf.keras.Model, object]:
         with open(f"{model_path}/charlist.txt") as file:
             charlist = list(char for char in file.read())
     except FileNotFoundError:
-        logger.error("charlist.txt not found at {model_path}. Exiting...")
+        logger.error(f"charlist.txt not found at {model_path}. Exiting...")
         sys.exit(1)
 
     utils = Utils(charlist, use_mask=True)

--- a/src/api/batch_predictor.py
+++ b/src/api/batch_predictor.py
@@ -412,7 +412,25 @@ def output_predictions(predictions: List[Tuple[float, str]],
     return outputs
 
 
-def output_prediction_error(output_path: str, group_id: str, identifier: str, text: str):
+def output_prediction_error(output_path: str,
+                            group_id: str,
+                            identifier: str,
+                            text: str):
+    """
+    Output an error message to a file.
+
+    Parameters
+    ----------
+    output_path : str
+        Base path where prediction outputs should be saved.
+    group_id : str
+        Group ID of the image.
+    identifier : str
+        Identifier of the image.
+    text : str
+        Error message to be saved.
+    """
+
     output_dir = os.path.join(output_path, group_id)
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)

--- a/src/api/batch_predictor.py
+++ b/src/api/batch_predictor.py
@@ -99,6 +99,7 @@ def batch_prediction_worker(prepared_queue: multiprocessing.JoinableQueue,
                 logger.error("Failed batch:")
                 for id in batch_identifiers:
                     logger.error(id)
+                    output_error(output_path, id, e)
                 predictions = []
 
             # Update the total number of predictions made
@@ -264,6 +265,8 @@ def safe_batch_predict(model: tf.keras.Model,
             logger.error(
                 "OOM error with single image. Skipping image"
                 f"{batch_info[0][1]}.")
+
+            output_error(output_path, batch_info[0][1], "OOM error")
             return []
 
         logger.warning(
@@ -406,3 +409,10 @@ def output_predictions(predictions: List[Tuple[float, str]],
             f.write(text + "\n")
 
     return outputs
+
+
+def output_error(output_dir: str, identifier: str, text: str):
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    with open(os.path.join(output_dir, identifier + ".error"), "w") as f:
+        f.write(text + "\n")

--- a/src/api/flask_app.py
+++ b/src/api/flask_app.py
@@ -55,7 +55,6 @@ if __name__ == '__main__':
 
     # Get Loghi-HTR options from environment variables
     logger.info("Getting Loghi-HTR options from environment variables")
-    model_path = get_env_variable("LOGHI_MODEL_PATH")
     batch_size = int(get_env_variable("LOGHI_BATCH_SIZE", "256"))
     output_path = get_env_variable("LOGHI_OUTPUT_PATH")
     max_queue_size = int(get_env_variable("LOGHI_MAX_QUEUE_SIZE", "10000"))
@@ -69,7 +68,6 @@ if __name__ == '__main__':
     request_queue, preparation_process, prediction_process = start_processes(
         batch_size,
         max_queue_size,
-        model_path,
         output_path,
         gpus
     )

--- a/src/api/flask_app.py
+++ b/src/api/flask_app.py
@@ -56,7 +56,6 @@ if __name__ == '__main__':
     # Get Loghi-HTR options from environment variables
     logger.info("Getting Loghi-HTR options from environment variables")
     model_path = get_env_variable("LOGHI_MODEL_PATH")
-    charlist_path = get_env_variable("LOGHI_CHARLIST_PATH")
     batch_size = int(get_env_variable("LOGHI_BATCH_SIZE", "256"))
     output_path = get_env_variable("LOGHI_OUTPUT_PATH")
     max_queue_size = int(get_env_variable("LOGHI_MAX_QUEUE_SIZE", "10000"))
@@ -71,7 +70,6 @@ if __name__ == '__main__':
         batch_size,
         max_queue_size,
         model_path,
-        charlist_path,
         output_path,
         gpus
     )

--- a/src/api/gunicorn_app.py
+++ b/src/api/gunicorn_app.py
@@ -85,7 +85,6 @@ if __name__ == "__main__":
     # Get Loghi-HTR options from environment variables
     logger.info("Getting Loghi-HTR options from environment variables")
     model_path = get_env_variable("LOGHI_MODEL_PATH")
-    charlist_path = get_env_variable("LOGHI_CHARLIST_PATH")
     batch_size = int(get_env_variable("LOGHI_BATCH_SIZE", "256"))
     output_path = get_env_variable("LOGHI_OUTPUT_PATH")
     max_queue_size = int(get_env_variable("LOGHI_MAX_QUEUE_SIZE", "10000"))
@@ -100,7 +99,6 @@ if __name__ == "__main__":
         batch_size,
         max_queue_size,
         model_path,
-        charlist_path,
         output_path,
         gpus
     )

--- a/src/api/gunicorn_app.py
+++ b/src/api/gunicorn_app.py
@@ -84,7 +84,6 @@ if __name__ == "__main__":
 
     # Get Loghi-HTR options from environment variables
     logger.info("Getting Loghi-HTR options from environment variables")
-    model_path = get_env_variable("LOGHI_MODEL_PATH")
     batch_size = int(get_env_variable("LOGHI_BATCH_SIZE", "256"))
     output_path = get_env_variable("LOGHI_OUTPUT_PATH")
     max_queue_size = int(get_env_variable("LOGHI_MAX_QUEUE_SIZE", "10000"))
@@ -98,7 +97,6 @@ if __name__ == "__main__":
     request_queue, preparation_process, prediction_process = start_processes(
         batch_size,
         max_queue_size,
-        model_path,
         output_path,
         gpus
     )

--- a/src/api/image_preparator.py
+++ b/src/api/image_preparator.py
@@ -47,17 +47,17 @@ def image_preparation_worker(batch_size: int,
 
     wait_count = 0
     old_model = None
+    batch_images, batch_groups, batch_identifiers = [], [], []
 
     try:
         while True:
-            batch_images, batch_groups, batch_identifiers = [], [], []
-
             while len(batch_images) < batch_size:
                 try:
                     image, group, identifier, model_path = request_queue.get(
                         timeout=TIMEOUT_DURATION)
                     logger.debug(f"Retrieved {identifier} from request_queue")
 
+                    # Check if the model has changed
                     if model_path != old_model:
                         logger.info(
                             "Model changed, adjusting image preparation")
@@ -66,39 +66,30 @@ def image_preparation_worker(batch_size: int,
                             logger.info(
                                 f"Sending old batch of {len(batch_images)} "
                                 "images")
-                            pad_batch(batch_images)
-                            prepared_queue.put(
-                                (np.array(batch_images), batch_groups,
-                                 batch_identifiers, old_model))
+
                             # Reset the batches after sending
                             batch_images, batch_groups, batch_identifiers = \
-                                [], [], []
+                                pad_and_queue_batch(batch_images, batch_groups,
+                                                    batch_identifiers,
+                                                    prepared_queue, old_model)
 
                         old_model = model_path
-                        try:
-                            num_channels = get_model_channels(model_path)
-                            logger.debug(
-                                f"New number of channels: "
-                                f"{num_channels}")
-                        except Exception as e:
-                            logger.error(f"Error: {e}")
-                            logger.error(
-                                "Error retrieving number of channels. "
-                                "Exiting...")
-                            return
+                        num_channels = update_channels(model_path, logger)
 
                     image = prepare_image(identifier, image, num_channels)
-
                     logger.debug(
                         f"Prepared image {identifier} with shape: "
                         f"{image.shape}")
 
+                    # Append the image to the batch
                     batch_images.append(image)
                     batch_groups.append(group)
                     batch_identifiers.append(identifier)
 
                     request_queue.task_done()
                     wait_count = 0
+
+                # If no new images are available, wait for a while
                 except Empty:
                     wait_count += 1
                     logger.debug(
@@ -108,19 +99,13 @@ def image_preparation_worker(batch_size: int,
                     if wait_count > MAX_WAIT_COUNT and len(batch_images) > 0:
                         break
 
-            pad_batch(batch_images)
-
-            logger.info(f"Prepared batch of {len(batch_images)} images")
-
-            # Push the prepared batch to the prepared_queue
-            prepared_queue.put(
-                (np.array(batch_images), batch_groups, batch_identifiers,
-                 old_model))
-            logger.debug("Pushed prepared batch to prepared_queue")
+            # Add the existing batch to the prepared_queue
+            batch_images, batch_groups, batch_identifiers = \
+                pad_and_queue_batch(batch_images, batch_groups,
+                                    batch_identifiers, prepared_queue,
+                                    old_model)
             logger.debug(
                 f"{request_queue.qsize()} images waiting to be processed")
-            logger.debug(
-                f"{prepared_queue.qsize()} batches ready for prediction")
 
     except KeyboardInterrupt:
         logger.warning(
@@ -129,7 +114,90 @@ def image_preparation_worker(batch_size: int,
         logger.error(f"Error: {e}")
 
 
-def pad_batch(batch_images):
+def pad_and_queue_batch(batch_images: np.ndarray,
+                        batch_groups: list,
+                        batch_identifiers: list,
+                        prepared_queue: multiprocessing.Queue,
+                        model_path: str) -> tuple:
+    """
+    Pad and queue a batch of images for prediction.
+
+    Parameters
+    ----------
+    batch_images : np.ndarray
+        Batch of images to be padded and queued.
+    batch_groups : list
+        List of groups to which the images belong.
+    batch_identifiers : list
+        List of identifiers for the images.
+    prepared_queue : multiprocessing.Queue
+        Queue to which the padded batch should be pushed.
+    model_path : str
+        Path to the model used for image preparation.
+
+    Returns
+    -------
+    tuple
+        Tuple containing the empty batch images, groups, and identifiers.
+    """
+
+    logger = logging.getLogger(__name__)
+
+    # Pad the batch
+    padded_batch = pad_batch(batch_images)
+
+    # Push the prepared batch to the prepared_queue
+    prepared_queue.put(
+        (np.array(padded_batch), batch_groups, batch_identifiers, model_path))
+    logger.debug("Pushed prepared batch to prepared_queue")
+    logger.debug(
+        f"{prepared_queue.qsize()} batches ready for prediction")
+
+    return [], [], []
+
+
+def update_channels(model_path: str, logger):
+    """
+    Update the model used for image preparation.
+
+    Parameters
+    ----------
+    model_path : str
+        The path to the directory containing the 'config.json' file.
+        The function will append "/config.json" to this path.
+    logger : logging.Logger
+        Logger object to log messages.
+    """
+
+    try:
+        num_channels = get_model_channels(model_path)
+        logger.debug(
+            f"New number of channels: "
+            f"{num_channels}")
+        return num_channels
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        logger.error(
+            "Error retrieving number of channels. "
+            "Exiting...")
+        return
+
+
+def pad_batch(batch_images: np.ndarray) -> np.ndarray:
+    """
+    Pad a batch of images to the same width.
+
+    Parameters
+    ----------
+    batch_images : np.ndarray
+        Batch of images to be padded.
+
+    Returns
+    -------
+    np.ndarray
+        Batch of padded images.
+    """
+
     # Determine the maximum width among all images in the batch
     max_width = max(image.shape[0] for image in batch_images)
 
@@ -137,6 +205,8 @@ def pad_batch(batch_images):
     for i in range(len(batch_images)):
         batch_images[i] = pad_to_width(
             batch_images[i], max_width, -10)
+
+    return batch_images
 
 
 def pad_to_width(image: tf.Tensor, target_width: int, pad_value: float):

--- a/src/api/image_preparator.py
+++ b/src/api/image_preparator.py
@@ -191,6 +191,10 @@ def prepare_image(identifier: str,
     image = tf.image.resize(image,
                             [target_height, target_width])
 
+    image = tf.image.resize_with_pad(image,
+                                     target_height,
+                                     target_width + 50)
+
     # Normalize the image and something else
     image = 0.5 - (image / 255)
 

--- a/src/api/image_preparator.py
+++ b/src/api/image_preparator.py
@@ -182,33 +182,6 @@ def pad_batch(batch_images: np.ndarray) -> np.ndarray:
     return batch_images
 
 
-def update_channels(model_path: str, logger):
-    """
-    Update the model used for image preparation.
-
-    Parameters
-    ----------
-    model_path : str
-        The path to the directory containing the 'config.json' file.
-        The function will append "/config.json" to this path.
-    logger : logging.Logger
-        Logger object to log messages.
-    """
-
-    try:
-        num_channels = get_model_channels(model_path)
-        logger.debug(
-            f"New number of channels: "
-            f"{num_channels}")
-        return num_channels
-    except Exception as e:
-        logger.error(f"Error: {e}")
-        logger.error(
-            "Error retrieving number of channels. "
-            "Exiting...")
-        return
-
-
 def pad_to_width(image: tf.Tensor, target_width: int, pad_value: float):
     """
     Pads a transposed image (where the first dimension is width) to a specified
@@ -249,6 +222,33 @@ def pad_to_width(image: tf.Tensor, target_width: int, pad_value: float):
 
     # Pad the image
     return tf.pad(image, padding, "CONSTANT", constant_values=pad_value)
+
+
+def update_channels(model_path: str, logger):
+    """
+    Update the model used for image preparation.
+
+    Parameters
+    ----------
+    model_path : str
+        The path to the directory containing the 'config.json' file.
+        The function will append "/config.json" to this path.
+    logger : logging.Logger
+        Logger object to log messages.
+    """
+
+    try:
+        num_channels = get_model_channels(model_path)
+        logger.debug(
+            f"New number of channels: "
+            f"{num_channels}")
+        return num_channels
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        logger.error(
+            "Error retrieving number of channels. "
+            "Exiting...")
+        return
 
 
 def prepare_image(image_bytes: bytes,

--- a/src/api/image_preparator.py
+++ b/src/api/image_preparator.py
@@ -59,11 +59,8 @@ def image_preparation_worker(batch_size: int,
                     logger.debug(f"Retrieved {identifier} from request_queue")
 
                     if model_path != old_model:
-                        old_model = model_path
-
                         logger.info(
                             "Model changed, adjusting image preparation")
-
                         if batch_images:
                             # Add the existing batch to the prepared_queue
                             logger.info(
@@ -76,6 +73,8 @@ def image_preparation_worker(batch_size: int,
                             # Reset the batches after sending
                             batch_images, batch_groups, batch_identifiers = \
                                 [], [], []
+
+                        old_model = model_path
                         try:
                             num_channels = get_model_channels(model_path)
                             logger.debug(

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -46,16 +46,17 @@ def predict() -> flask.Response:
 
     # Add incoming request to queue
     # Here, we're just queuing the raw data.
-    image_file, group_id, identifier = extract_request_data()
+    image_file, group_id, identifier, model = extract_request_data()
 
     logger = logging.getLogger(__name__)
 
     logger.debug(f"Data received: {group_id}, {identifier}")
     logger.debug(f"Adding {identifier} to queue")
+    logger.debug(f"Using model {model}")
 
     try:
-        app.request_queue.put((image_file, group_id, identifier), block=True,
-                              timeout=30)
+        app.request_queue.put((image_file, group_id, identifier, model),
+                              block=True, timeout=30)
     except Full:
         response = jsonify({
             "status": "error",

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -56,7 +56,7 @@ def predict() -> flask.Response:
 
     try:
         app.request_queue.put((image_file, group_id, identifier, model),
-                              block=True, timeout=30)
+                              block=True, timeout=15)
     except Full:
         response = jsonify({
             "status": "error",

--- a/src/api/start_local_app.sh
+++ b/src/api/start_local_app.sh
@@ -3,8 +3,6 @@ export GUNICORN_WORKERS=1
 export GUNICORN_THREADS=1
 export GUNICORN_ACCESSLOG='-'
 
-export LOGHI_MODEL_PATH="/home/tim/Downloads/new_model/"
-export LOGHI_CHARLIST_PATH="/home/tim/Downloads/new_model/charlist.txt"
 export LOGHI_BATCH_SIZE=300
 export LOGHI_OUTPUT_PATH="/home/tim/Documents/development/loghi-htr/output/"
 export LOGHI_MAX_QUEUE_SIZE=50000


### PR DESCRIPTION
# This PR adds

## API

- API now recursively retries batch when it causes an OOM error. If the batch size is 1 and OOM fails, only fail that image.
- Padding more closely matches training padding
- `charlist.txt` is now read automatically from model path. Note: environment variable `LOGHI_CHARLIST_PATH` is no longer used
- Model switching is enabled. This is done with the `model` field in the API call. Note: environment variable `LOGHI_MODEL_PATH` is no longer used
- Images that fail during prediction are logged to `group/identifier.error`
- Reduced max request waiting period to 15 seconds