### PR TITLE
Fix tests and remove old args in example configs

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,9 +15,6 @@ jobs:
       with:
         python-version: '3.10'
 
-    - name: Install system dependencies
-      run: sudo apt-get update && sudo apt-get install -y libgl1-mesa-glx
-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/configs/default.json
+++ b/configs/default.json
@@ -21,11 +21,11 @@
         },
         "general": {
             "batch_size": 4,
-            "charlist": null,
             "config_file": null,
             "gpu": "0",
             "output": "output",
-            "seed": 42
+            "seed": 42,
+            "tokenizer": null
         },
         "inference": {
             "inference_list": null,
@@ -41,6 +41,7 @@
             "warmup_ratio": 0.0
         },
         "misc": {
+            "decoding_threads": 2,
             "deterministic": false
             "normalization_file": null
         },

--- a/configs/finetuning.json
+++ b/configs/finetuning.json
@@ -49,7 +49,6 @@
             "do_validate": true,
             "early_stopping_patience": 10,
             "epochs": 50,
-            "max_queue_size": 256,
             "output_checkpoints": true,
             "train_list": "/path/to/train.txt",
             "training_verbosity_mode": "auto",

--- a/configs/inference.json
+++ b/configs/inference.json
@@ -17,7 +17,6 @@
             "results_file": "output/results.txt"
         },
         "misc": {
-            "check_missing_files": false,
             "deterministic": false
         },
         "model": {

--- a/configs/testing.json
+++ b/configs/testing.json
@@ -19,7 +19,6 @@
             "use_float32": false
         },
         "training": {
-            "max_queue_size": 256,
             "test_list": "/path/to/test.txt"
         }
     }

--- a/configs/training.json
+++ b/configs/training.json
@@ -44,7 +44,6 @@
             "do_validate": true,
             "early_stopping_patience": 20,
             "epochs": 100,
-            "max_queue_size": 256,
             "output_checkpoints": true,
             "train_list": "/path/to/train.txt",
             "training_verbosity_mode": "auto",

--- a/configs/validation.json
+++ b/configs/validation.json
@@ -20,7 +20,6 @@
         },
         "training": {
             "do_validate": true,
-            "max_queue_size": 256,
             "validation_list": "/path/to/validation.txt"
         }
     }


### PR DESCRIPTION
This PR removes some old arguments from the example configs in the `configs/` dir.

Due to tests moving to `Ubuntu 24.04`, the `libgl1-mesa-glx` installation failed. Removed this to fix tests building.